### PR TITLE
Refactor panotpes auth into SocialPanoptes class

### DIFF
--- a/hamlet/views.py
+++ b/hamlet/views.py
@@ -9,20 +9,13 @@ from panoptes_client import Panoptes, Project, SubjectSet, Workflow
 from exports.forms import WorkflowExportForm
 from exports.models import SubjectSetExport, WorkflowExport
 from .celery import subject_set_export, workflow_export
+from .zooniverse_auth import SocialPanoptes
 
 
 @login_required
 def index(request):
     social = request.user.social_auth.get(provider='zooniverse')
-    with Panoptes() as p:
-        p.bearer_token = social.access_token
-        p.logged_in = True
-        p.refresh_token = social.extra_data['refresh_token']
-        p.bearer_expires = (
-                datetime.fromtimestamp(social.extra_data['auth_time'])
-                + timedelta(social.extra_data['expires_in'])
-            )
-
+    with SocialPanoptes(bearer_token=social.access_token) as p:
         context = {
             'projects': Project.where(owner=request.user.username),
         }
@@ -33,15 +26,7 @@ def index(request):
 @login_required
 def project(request, project_id):
     social = request.user.social_auth.get(provider='zooniverse')
-    with Panoptes() as p:
-        p.bearer_token = social.access_token
-        p.logged_in = True
-        p.refresh_token = social.extra_data['refresh_token']
-        p.bearer_expires = (
-                datetime.fromtimestamp(social.extra_data['auth_time'])
-                + timedelta(social.extra_data['expires_in'])
-            )
-
+    with SocialPanoptes(bearer_token=social.access_token) as p:
         subject_set_exports = []
 
         for subject_set in SubjectSet.where(project_id=project_id):
@@ -81,7 +66,6 @@ def subject_set(request, subject_set_id, project_id):
     subject_set_export.delay(
         export.id,
         social.access_token,
-        social.extra_data,
     )
     return redirect('project', project_id=project_id)
 
@@ -92,20 +76,10 @@ def workflow(request, workflow_id, project_id):
         form = WorkflowExportForm(request.POST)
         if form.is_valid():
             social = request.user.social_auth.get(provider='zooniverse')
-            with Panoptes() as p:
-                p.bearer_token = social.access_token
-                p.logged_in = True
-                p.refresh_token = social.extra_data['refresh_token']
-                p.bearer_expires = (
-                        datetime.fromtimestamp(social.extra_data['auth_time'])
-                        + timedelta(social.extra_data['expires_in'])
-                    )
-
             export = WorkflowExport.objects.create(workflow_id=workflow_id)
             workflow_export.delay(
                 export.id,
                 social.access_token,
-                social.extra_data,
                 form.cleaned_data['storage_prefix'],
             )
     return redirect('project', project_id=project_id)


### PR DESCRIPTION
Also stops passing expiration times and refresh token to Panoptes
client, because social_core will handle refreshing the token and the
client doesn't support the correct oauth flow anyway.