### PR TITLE
Pin Python version to 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 LABEL maintainer="contact@zooniverse.org"
 


### PR DESCRIPTION
Python 3.8 is out and it broke Celery.