### PR TITLE
Make ML Task request to ML Service

### DIFF
--- a/hamlet/celery.py
+++ b/hamlet/celery.py
@@ -271,7 +271,13 @@ def workflow_export(
 
             export.status = WorkflowExport.COMPLETE
             export.save()
-            
+    except Exception as e:
+        try:
+            self.retry(countdown=60)
+        except MaxRetriesExceededError:
+            export.status = WorkflowExport.FAILED
+            export.save()
+            raise e
     finally:
         os.unlink(out_f_name)
 

--- a/hamlet/celery.py
+++ b/hamlet/celery.py
@@ -271,14 +271,7 @@ def workflow_export(
 
             export.status = WorkflowExport.COMPLETE
             export.save()
-    except Exception as err:
-        # try:
-        #     self.retry(countdown=60)
-        # except MaxRetriesExceededError:
-        #     export.status = WorkflowExport.FAILED
-        #     export.save()
-        #     raise err
-        raise err
+            
     finally:
         os.unlink(out_f_name)
 
@@ -466,30 +459,25 @@ def ml_subject_assistant_export_to_microsoft_pt3_create_shareable_azure_blob(
 def ml_subject_assistant_export_to_microsoft_pt4_make_ml_request(shareable_file_url):
     ml_task_id = None
     
-    try:
-      
-        ml_service_caller_id = os.environ.get('SUBJECT_ASSISTANT_ML_SERVICE_CALLER_ID')
-        ml_service_url = os.environ.get('SUBJECT_ASSISTANT_ML_SERVICE_URL')
-        
-        req_url = ml_service_url + '/request_detections'
-        req_body = {
-            'images_requested_json_sas': shareable_file_url,
-            'use_url': 'true',
-            'request_name': 'zooniverse-subject-assistant',  # Note: this field may be optional
-            'caller': ml_service_caller_id
-        }
-        
-        res = requests.post(
-            req_url,
-            json=req_body,
-            headers={'Content-Type': 'application/json'}
-        )
-        res.raise_for_status()
-        
-        response_json = res.json()
-        ml_task_id = response_json['request_id']
+    ml_service_caller_id = os.environ.get('SUBJECT_ASSISTANT_ML_SERVICE_CALLER_ID')
+    ml_service_url = os.environ.get('SUBJECT_ASSISTANT_ML_SERVICE_URL')
 
-    except Exception as err:
-        raise err
-  
+    req_url = ml_service_url + '/request_detections'
+    req_body = {
+        'images_requested_json_sas': shareable_file_url,
+        'use_url': 'true',
+        'request_name': 'zooniverse-subject-assistant',  # Note: this field may be optional
+        'caller': ml_service_caller_id
+    }
+
+    res = requests.post(
+        req_url,
+        json=req_body,
+        headers={'Content-Type': 'application/json'}
+    )
+    res.raise_for_status()
+
+    response_json = res.json()
+    ml_task_id = response_json['request_id']
+        
     return ml_task_id

--- a/hamlet/celery.py
+++ b/hamlet/celery.py
@@ -322,9 +322,6 @@ def ml_subject_assistant_export_to_microsoft(
         # Upload the file to Azure, and get a shareable URL to the file
         shareable_file_url = ml_subject_assistant_export_to_microsoft_pt3_create_shareable_azure_blob(source_filepath, target_filename)
         
-        # SUCCESS
-        export.status = MLSubjectAssistantExport.COMPLETE
-        
         # Save the created file to the database
         # NOTE: this is technically optional, and only used as a backup
         with open(source_filepath, 'rb') as out_f:
@@ -336,6 +333,12 @@ def ml_subject_assistant_export_to_microsoft(
         # Save a refrence to the shareable URL.
         # NOTE: these shareable URLs have a shelf life.
         export.azure_url = shareable_file_url
+        
+        # Submit the ML task request to the ML service
+        export.ml_task_id = ml_subject_assistant_export_to_microsoft_pt4_make_ml_request(shareable_file_url)
+        
+        # SUCCESS
+        export.status = MLSubjectAssistantExport.COMPLETE
         export.save()
     
     except Exception as e:
@@ -458,3 +461,10 @@ def ml_subject_assistant_export_to_microsoft_pt3_create_shareable_azure_blob(
         raise err
     
     return shareable_file_url
+
+def ml_subject_assistant_export_to_microsoft_pt4_make_ml_request(shareable_file_url):
+    ml_task_id = None
+  
+    ml_service_caller = os.environ.get('SUBJECT_ASSISTANT_ML_SERVICE_CALLER')
+  
+    return ml_task_id

--- a/hamlet/celery.py
+++ b/hamlet/celery.py
@@ -471,9 +471,6 @@ def ml_subject_assistant_export_to_microsoft_pt4_make_ml_request(shareable_file_
         ml_service_caller_id = os.environ.get('SUBJECT_ASSISTANT_ML_SERVICE_CALLER_ID')
         ml_service_url = os.environ.get('SUBJECT_ASSISTANT_ML_SERVICE_URL')
         
-        print('POST START')
-        print('--------------------------------------------------------------------------------')
-        
         req_url = ml_service_url + '/request_detections'
         req_body = {
             'images_requested_json_sas': shareable_file_url,
@@ -482,39 +479,17 @@ def ml_subject_assistant_export_to_microsoft_pt4_make_ml_request(shareable_file_
             'caller': ml_service_caller_id
         }
         
-        print(req_url)
-        print(req_body)
-        
-        print('--------------------------------------------------------------------------------')
-        
         res = requests.post(
             req_url,
             json=req_body,
             headers={'Content-Type': 'application/json'}
         )
         res.raise_for_status()
-
-        print('POST SUCCESS')
-        print('--------------------------------------------------------------------------------')
-        print(res.json())
         
         response_json = res.json()
         ml_task_id = response_json['request_id']
-        
-        print('--------------------------------------------------------------------------------')
-        print('POST DONE')
 
     except Exception as err:
-        print('ERROR')
-        print('--------------------------------------------------------------------------------')
-        print(err)
-        print('--------------------------------------------------------------------------------')
-      
-        # try:
-        #     self.retry(countdown=60)
-        # except MaxRetriesExceededError:
-        #     raise err
-        
         raise err
   
     return ml_task_id

--- a/templates/ml-subject-assistant.html
+++ b/templates/ml-subject-assistant.html
@@ -20,14 +20,22 @@
             &nbsp;&middot;&nbsp;
             <label>
               JSON (AWS):
-              <input type="text" name="download-url" value="{{ data_export.0.json.url }}" readonly>
+              <input type="text" name="json-url" value="{{ data_export.0.json.url }}" readonly>
             </label>
           {% endif %}
           {% if data_export.0.azure_url %}
             &nbsp;&middot;&nbsp;
             <label>
               Azure URL:
-              <input type="text" name="azure" value="{{ data_export.0.azure_url }}" readonly>
+              <input type="text" name="azure-url" value="{{ data_export.0.azure_url }}" readonly>
+            </label>
+          {% endif %}
+          
+          {% if data_export.0.ml_task_id %}
+            &nbsp;&middot;&nbsp;
+            <label>
+              ML Task ID:
+              <input type="text" name="ml-task-id" value="{{ data_export.0.ml_task_id }}" readonly>
             </label>
           {% endif %}
         </form>


### PR DESCRIPTION
## PR Overview

Requires #127 

Once PR 127 creates and stores the subject manifest file on Azure, a "Machine Learning Task" request needs to be submitted to the Machine Learning service. This tells the service that, hey, please take a look at this funky fresh new subject manifest file.

This PR submits that request.

- A fourth sub-task has been added to the `ml_subject_assistant_export_to_microsoft()` Celery task.
- This sub-tasks submits a properly formatted POST to the ML service, and receives a "request_id" in return, which is saved to the database.
- This "request_id" can later be passed to the Subject Assistant front end.

New Requirements:
- for the new functionality to work, the following variables now need to be specified in the environment: `SUBJECT_ASSISTANT_ML_SERVICE_CALLER_ID`, `SUBJECT_ASSISTANT_ML_SERVICE_URL`

### Status

Needs some cleanup, then ready for review.