### PR TITLE
Fix Subject Assistant's 'index out of bounds' error

### DIFF
--- a/hamlet/views.py
+++ b/hamlet/views.py
@@ -121,8 +121,8 @@ def ml_subject_assistant_list(request, project_id):
             ).order_by('-created')
             
             external_web_app_url = settings.SUBJECT_ASSISTANT_EXTERNAL_URL 
-            if data_export and list(data_export)[0].ml_task_id:
-                external_web_app_url = external_web_app_url + str(list(data_export)[0].ml_task_id)
+            if data_export.first() and data_export.first().ml_task_id:
+                external_web_app_url = external_web_app_url + str(data_export.first().ml_task_id)
           
             ml_subject_assistant_exports.append((
                 subject_set,

--- a/hamlet/views.py
+++ b/hamlet/views.py
@@ -121,7 +121,7 @@ def ml_subject_assistant_list(request, project_id):
             ).order_by('-created')
             
             external_web_app_url = settings.SUBJECT_ASSISTANT_EXTERNAL_URL 
-            if list(data_export)[0].ml_task_id:
+            if len(list(data_export)) > 0 and list(data_export)[0].ml_task_id:
                 external_web_app_url = external_web_app_url + str(list(data_export)[0].ml_task_id)
           
             ml_subject_assistant_exports.append((

--- a/hamlet/views.py
+++ b/hamlet/views.py
@@ -121,7 +121,7 @@ def ml_subject_assistant_list(request, project_id):
             ).order_by('-created')
             
             external_web_app_url = settings.SUBJECT_ASSISTANT_EXTERNAL_URL 
-            if len(list(data_export)) > 0 and list(data_export)[0].ml_task_id:
+            if data_export and list(data_export)[0].ml_task_id:
                 external_web_app_url = external_web_app_url + str(list(data_export)[0].ml_task_id)
           
             ml_subject_assistant_exports.append((


### PR DESCRIPTION
## PR Overview

This PR fixes an issue on the Subject Assistant pages which causes 500 error pages when a Subject Set never had a history of being exported.

- Error occurs when a user visits a Subject Assistant Project page (e.g. `http://localhost:8080/subject-assistant/10560/`) with a Subject Set that hasn't been exported (i.e. no export data in the database)
- Error located at `hamlet/views.py`, in function `ml_subject_assistant_list()`.
- Solution is a simple existence check.

Tested on localhost using a Zooniverse user with a Project with un-exported Subject Sets. Subject Assistant page continues to work for users with exported Subject Sets. 

### Status

Ready for review!
