### PR TITLE
Fix ML Subject Assistant's missing environment variables

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -69,6 +69,31 @@ spec:
                 secretKeyRef:
                   name: hamlet-staging-conf
                   key: PANOPTES_SECRET
+            - name: SUBJECT_ASSISTANT_AZURE_ACCOUNT_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_AZURE_ACCOUNT_NAME
+            - name: SUBJECT_ASSISTANT_AZURE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_AZURE_ACCOUNT_KEY
+            - name: SUBJECT_ASSISTANT_AZURE_CONTAINER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_AZURE_CONTAINER_NAME
+            - name: SUBJECT_ASSISTANT_ML_SERVICE_CALLER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_ML_SERVICE_CALLER_ID
+            - name: SUBJECT_ASSISTANT_ML_SERVICE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_ML_SERVICE_URL
             - name: DJANGO_ENV
               value: staging
             - name: REDIS_URI
@@ -132,6 +157,31 @@ spec:
                 secretKeyRef:
                   name: hamlet-staging-conf
                   key: PANOPTES_SECRET
+            - name: SUBJECT_ASSISTANT_AZURE_ACCOUNT_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_AZURE_ACCOUNT_NAME
+            - name: SUBJECT_ASSISTANT_AZURE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_AZURE_ACCOUNT_KEY
+            - name: SUBJECT_ASSISTANT_AZURE_CONTAINER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_AZURE_CONTAINER_NAME
+            - name: SUBJECT_ASSISTANT_ML_SERVICE_CALLER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_ML_SERVICE_CALLER_ID
+            - name: SUBJECT_ASSISTANT_ML_SERVICE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hamlet-staging-conf
+                  key: SUBJECT_ASSISTANT_ML_SERVICE_URL
             - name: DJANGO_ENV
               value: staging
             - name: REDIS_URI


### PR DESCRIPTION
## PR Overview

This fixes an issue where the deployed Kubernetes pods weren't reading the Environment Variables (for the Subject Assistant) from the Secrets. Issue was that I didn't realise that I had to _manually map_ the Subject Assistant's Secrets to the pod's env variables.

### Dev Notes

Lessons learned: if you want a Environmental variable (Secret) in your Kubernetes pod...

1. you need to make sure your app code reads the Env variable from process.env.MY_DB_PASSWORD or whatever.
2. make sure you set your MY_DB_PASSWORD values in your Kubernetes Secrets.
3. map the values from the Secrets to the Environment variables in your Kubernetes deployment.tmpl file. 
4. and if you change the value of the Secrets (e.g. via kubectl edit secrets XYZ), remember to restart the Kubernetes pod

(In this PR's case, merging this PR will auto-refresh the pod, so no worries about Step 4.)

### Status

Ready for review!
