### PR TITLE
Add Nginx and static file support

### DIFF
--- a/hamlet/settings.py
+++ b/hamlet/settings.py
@@ -139,7 +139,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'hamlet', 'static')
+STATIC_ROOT = os.getenv('STATIC_ROOT', os.path.join(BASE_DIR, 'hamlet', 'static'))
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),
 ]

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -22,13 +22,6 @@ data:
 
       location / {
         proxy_pass http://docker-hamlet;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_buffer_size   128k;
-        proxy_buffers   4 256k;
-        proxy_busy_buffers_size   256k;
       }
     }
 ---

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -5,7 +5,7 @@ metadata:
 data:
   nginx.conf: |+
     upstream docker-hamlet {
-      server localhost:81;
+      server localhost:8080;
     }
 
     server {

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -70,6 +70,11 @@ spec:
              limits:
                memory: "100Mi"
                cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
           env:
             - name: DB_HOST
               valueFrom:

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -143,9 +143,11 @@ spec:
               value: staging
             - name: REDIS_URI
               value: "redis://hamlet-staging-redis"
+            - name: STATIC_ROOT
+              value: "/static-assets"
           volumeMounts:
             - name: static-assets
-              mountPath: "/static"
+              mountPath: "/static-assets"
         - name: hamlet-staging-nginx
           image: zooniverse/apps-nginx:xenial
           resources:

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -1,3 +1,36 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: hamlet-nginx-conf-staging
+data:
+  nginx.conf: |+
+    upstream docker-hamlet {
+      server localhost:81;
+    }
+
+    server {
+      server_name hamlet-staging.zooniverse.org
+      include /etc/nginx/ssl.default.conf;
+      gzip_types *;
+
+      location ~ ^/static/ {
+        root /static-assets/;
+        gzip_static on; # to serve pre-gzipped version
+        expires max;
+        add_header Cache-Control public;
+      }
+
+      location / {
+        proxy_pass http://docker-hamlet;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_buffer_size   128k;
+        proxy_buffers   4 256k;
+        proxy_busy_buffers_size   256k;
+      }
+    }
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -112,56 +145,36 @@ spec:
               value: staging
             - name: REDIS_URI
               value: "redis://hamlet-staging-redis"
-          volumeMounts:  # ??? Is this necessary?
-            - name: static-assets
-              mountPath: "/static"
-
-        - name: hamlet-staging-nginx
-          image: zooniverse/apps-nginx:xenial
-          ports:
-            - containerPort: 80  # ??? could this conflict with the Django app?
           volumeMounts:
             - name: static-assets
               mountPath: "/static"
+        - name: hamlet-staging-nginx
+          image: zooniverse/apps-nginx:xenial
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "10m"
+            limits:
+              memory: "100Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: static-assets
+              mountPath: "/static-assets"
+            - name: hamlet-nginx-conf
+              mountPath: "/etc/nginx-sites"
       volumes:
         - name: static-assets
-          configMap:  # ??? use EmptyDir: {} instead of the ConfigMap?
+          emptyDir: {}
+        - name: hamlet-nginx-conf
+          configMap:
             name: hamlet-nginx-conf-staging
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  name: hamlet-nginx-conf-staging
-data:
-  nginx.conf: |+
-    upstream docker-hamlet {
-      server localhost:81;
-    }
-
-    server {
-      server_name hamlet-staging.zooniverse.org
-      include /etc/nginx/ssl.default.conf;
-      gzip_types *;
-
-      location ~ ^/static/ {
-        root /hamlet/static/;
-        gzip_static on; # to serve pre-gzipped version
-        expires max;
-        add_header Cache-Control public;
-      }
-
-      location / {
-        proxy_pass http://docker-hamlet;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_buffer_size   128k;
-        proxy_buffers   4 256k;
-        proxy_busy_buffers_size   256k;
-      }
-    }
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -298,7 +298,7 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 80
   type: NodePort
 ---
 kind: PersistentVolumeClaim

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -112,6 +112,56 @@ spec:
               value: staging
             - name: REDIS_URI
               value: "redis://hamlet-staging-redis"
+          volumeMounts:  # ??? Is this necessary?
+            - name: static-assets
+              mountPath: "/static"
+
+        - name: hamlet-staging-nginx
+          image: zooniverse/apps-nginx:xenial
+          ports:
+            - containerPort: 80  # ??? could this conflict with the Django app?
+          volumeMounts:
+            - name: static-assets
+              mountPath: "/static"
+      volumes:
+        - name: static-assets
+          configMap:  # ??? use EmptyDir: {} instead of the ConfigMap?
+            name: hamlet-nginx-conf-staging
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: hamlet-nginx-conf-staging
+data:
+  nginx.conf: |+
+    upstream docker-hamlet {
+      server localhost:81;
+    }
+
+    server {
+      server_name hamlet-staging.zooniverse.org
+      include /etc/nginx/ssl.default.conf;
+      gzip_types *;
+
+      location ~ ^/static/ {
+        root /hamlet/static/;
+        gzip_static on; # to serve pre-gzipped version
+        expires max;
+        add_header Cache-Control public;
+      }
+
+      location / {
+        proxy_pass http://docker-hamlet;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_buffer_size   128k;
+        proxy_buffers   4 256k;
+        proxy_busy_buffers_size   256k;
+      }
+    }
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## PR Overview

Closes #211 
Additional details: #210 

This PR attempts to add an Nginx server to the Hamlet deployment, so the Hamlet app can serve static files. This PR only affects **production deployment** and has no effect on staging/development modes.

Notes:
- Static files at the `/static` URL should be visible to all users.
  - e.g.: https://hamlet-staging.zooniverse.org/static/zooniverse-logo-white.png
- On the server's file system, the static files would be found in the `(project's BASE_DIR)/hamlet/static` folder, if I'm correct. (🤔)

### Status

Do not merge. Awaiting review and advice from @camallen 

Additional comments on what I _think_ I'm doing to follow.