### PR TITLE
Fix nginx deployment configs for static assets

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -148,7 +148,7 @@ spec:
             - name: REDIS_URI
               value: "redis://hamlet-staging-redis"
             - name: STATIC_ROOT
-              value: "/static-assets"
+              value: "/static-assets/static/"
           volumeMounts:
             - name: static-assets
               mountPath: "/static-assets"

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -71,6 +71,9 @@ spec:
             httpGet:
               path: /
               port: 8080
+              httpHeaders:
+                 - name: Host
+                   value: "hamlet-staging.zooniverse.org"
             initialDelaySeconds: 10
           env:
             - name: DB_HOST
@@ -165,6 +168,9 @@ spec:
             httpGet:
               path: /
               port: 80
+              httpHeaders:
+                 - name: Host
+                   value: "hamlet-staging.zooniverse.org"
             initialDelaySeconds: 10
           ports:
             - containerPort: 80

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -13,6 +13,10 @@ data:
       include /etc/nginx/ssl.default.conf;
       gzip_types *;
 
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
       location ~ ^/static/ {
         root /static-assets/;
         gzip_static on; # to serve pre-gzipped version


### PR DESCRIPTION
1. fix the static assets path for serving via nginx
2. ensure we pass the HOST to the upstream proxy DJANGO app
3. update the the liveness probes to correctly test the app