### PR TITLE
use SSL connection mode in non-dev envs

### DIFF
--- a/hamlet/settings.py
+++ b/hamlet/settings.py
@@ -95,7 +95,7 @@ DATABASES = {
         'PASSWORD': os.environ.get('DB_PASSWORD', 'hamlet'),
         'HOST': os.environ.get('DB_HOST', 'postgres'),
         'PORT': os.environ.get('DB_PORT', 5432),
-        'OPTIONS': {'sslmode': 'prefer'}
+        'OPTIONS': {'sslmode': 'prefer'},
     }
 }
 

--- a/hamlet/settings.py
+++ b/hamlet/settings.py
@@ -95,6 +95,7 @@ DATABASES = {
         'PASSWORD': os.environ.get('DB_PASSWORD', 'hamlet'),
         'HOST': os.environ.get('DB_HOST', 'postgres'),
         'PORT': os.environ.get('DB_PORT', 5432),
+        'OPTIONS': {'sslmode': 'prefer'}
     }
 }
 


### PR DESCRIPTION
use an SSL connection by default for the non-dev dbs and fallback to non-ssl mode for local deb / CI envs
> first try an SSL connection; if that fails, try a non-SSL connection
https://www.postgresql.org/docs/11/libpq-connect.html