### PR TITLE
Allow deploy envs DB connections to be secure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   postgres:
-    image: postgres:9.4
+    image: postgres:11
     volumes:
       - ./postgres_data:/var/lib/postgresql/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
       - AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}
 
+  # Flower is a celery monitoring tool
   flower:
     build:
       context: .

--- a/hamlet/settings.py
+++ b/hamlet/settings.py
@@ -95,7 +95,7 @@ DATABASES = {
         'PASSWORD': os.environ.get('DB_PASSWORD', 'hamlet'),
         'HOST': os.environ.get('DB_HOST', 'postgres'),
         'PORT': os.environ.get('DB_PORT', 5432),
-        'OPTIONS': {'sslmode': 'prefer'},
+        'OPTIONS': {'sslmode': os.environ.get('DB_SSL_MODE', 'prefer')},
     }
 }
 

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -76,6 +76,8 @@ spec:
                    value: "hamlet-staging.zooniverse.org"
             initialDelaySeconds: 10
           env:
+            - name: DB_SSL_MODE
+              value: require
             - name: DB_HOST
               valueFrom:
                 secretKeyRef:
@@ -159,7 +161,7 @@ spec:
           image: zooniverse/apps-nginx:xenial
           resources:
             requests:
-              memory: "100Mi"
+              memory: "60Mi"
               cpu: "10m"
             limits:
               memory: "100Mi"
@@ -210,13 +212,15 @@ spec:
           image: zooniverse/hamlet:__IMAGE_TAG__
           resources:
              requests:
-               memory: "500Mi"
+               memory: "250Mi"
                cpu: "10m"
              limits:
                memory: "500Mi"
                cpu: "500m"
           args: ["bash", "/usr/src/app/start_worker.sh"]
           env:
+            - name: DB_SSL_MODE
+              value: require
             - name: DB_HOST
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Match the server requirements for SSL mode but still allow the dev machines to boot via docker-compose