### PR TITLE
simplify the docker build tags in jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,10 +13,9 @@ pipeline {
       steps {
         script {
           def dockerRepoName = 'zooniverse/hamlet'
-          def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
+          def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
           def newImage = docker.build(dockerImageName)
           newImage.push()
-          newImage.push('${GIT_COMMIT}')
 
           if (BRANCH_NAME == 'master') {
             stage('Update latest tag') {


### PR DESCRIPTION
no need to track the branch name via image tags, just the git sha ref is used for deployment