### PR TITLE
allow system to report the deployed state of the service

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -17,6 +17,12 @@ data:
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+      location = /commit_id.txt {
+        root /static-assets/;
+        expires off;
+        add_header Cache-Control public;
+      }
+
       location ~ ^/static/ {
         root /static-assets/;
         gzip_static on; # to serve pre-gzipped version

--- a/start_server.sh
+++ b/start_server.sh
@@ -10,6 +10,7 @@ python manage.py migrate --noinput
 
 if [ "$DJANGO_ENV" == "production" ] || [ "$DJANGO_ENV" == "staging" ]; then
   if [ ! -d "hamlet/static" ]; then
+    if [ -f "commit_id.txt" ]; then cp commit_id.txt static/ ; fi
     echo Generating static files
     python manage.py collectstatic --clear --no-input
   fi


### PR DESCRIPTION
Add commit_id.txt to the static assets and ensure we serve that off the root via a custom nginx location directive