### PR TITLE
use internal non tls scheme for internal k8s traffic

### DIFF
--- a/hamlet/kade_service.py
+++ b/hamlet/kade_service.py
@@ -8,11 +8,16 @@ def env_string_upcase():
     return env_string().upper()
 
 def url():
+    # allow service URL to be set by env vars
+    kade_service_url = os.environ.get('KADE_SUBJECT_ASSISTANT_SERVICE_URL')
+    if kade_service_url:
+        return kade_service_url
+
     # construct the KaDE service host ENV name from K8s env vars
     # this will be an internal k8s cluster host DNS so avoids routing through the internet
     kade_service_host = os.environ.get(
       f'KADE_{env_string_upcase()}_APP_SERVICE_HOST', 'kade-staging.zooniverse.org')
-    return f'https://{kade_service_host}/prediction_jobs'
+    return f'http://{kade_service_host}/prediction_jobs'
 
 
 # configure the KaDE API basic auth credentials


### PR DESCRIPTION
allow the kade service URL to be set via and env var and fall back to non tls scheme url from k8s service envs