### PR TITLE
allow deploys via production-release tag

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -2,7 +2,7 @@ name: Deploy to Production
 
 on:
   push:
-    branches:
+    tags:
       - production-release
   workflow_dispatch:
 


### PR DESCRIPTION
prod deploy is tag based so reflect this in the GH actions workflow yaml